### PR TITLE
Replaced the older test with the gtest tests in the cmake build.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,11 +11,87 @@ set (LIBAIS_VERSION_MINOR 6)
 #  "${PROJECT_BINARY_DIR}/ais.h"
 #  )
 
-include_directories("${PROJECT_BINARY_DIR}")
+#include_directories("${PROJECT_BINARY_DIR}")
 
-add_library(ais SHARED STATIC ais ais1_2_3 ais4_11 ais5 ais7_13 ais8 ais9 ais10 ais12 ais14 ais15 ais18 ais19 ais21 ais24 ais8_366_22 )
+set (HEADERS
+    ais.h
+    ais8_001_22.h
+    ais8_366_22.h
+)
 
-add_executable(test_libais test_libais)
-target_link_libraries (test_libais ais)
+set (SOURCES
+    ais
+    ais1_2_3
+    ais4_11
+    ais5
+    ais7_13
+    ais8 ais8_001_22 ais8_366_22
+    ais9
+    ais10
+    ais12
+    ais14
+    ais15
+    ais18
+    ais19
+    ais21
+    ais24
+    ais8_366_22
+)
+
+install(FILES ${HEADERS} DESTINATION include)
+
+add_library(ais STATIC  ${SOURCES} )
+install(TARGETS ais DESTINATION lib)
+
+
+# testing support
+
+option(BUILD_TESTS  "Enable testing." OFF)
+
+if(BUILD_TESTS)
+
+    option(TESTS_NEED_PTHREADS "Enable if tests need to link agains pthreads" OFF)
+    option(SEPARATE_TESTS "Enable if separate tests should be built, otherwise a single test executable will be built containing all tests" ON)
+
+    find_path(gtest_INCLUDE_DIR gtest/test.h)
+    find_library(gtest_LIBRARY gtest)
+    find_library(gtest_main_LIBRARY gtest_main)
+
+    if(gtest_INCLUDE_DIR AND gtest_LIBRARY AND gtest_main_LIBRARY)
+        include_directories(${gtest_INCLUDE_DIR})
+        set(TEST_LIBS ${TEST_LIBS} ${gtest_LIBRARY} ${gtest_main_LIBRARY})
+    else()
+        message(FATAL_ERROR "gtest not found")
+    endif()
+
+    if(TESTS_NEED_PTHREADS)
+        find_package(Threads)
+        if(CMAKE_THREAD_LIBS_INIT AND CMAKE_USE_PTHREADS_INIT)
+            set(TEST_LIBS ${TEST_LIBS} ${CMAKE_THREAD_LIBS_INIT})
+        else()
+            message(FATAL_ERROR "pthreads not found")
+        endif()
+    endif()
+
+    set (TEST_SOURCES
+        ais1_2_3_unittest
+        ais8_001_22_unittest
+    )
+
+    enable_testing()
+
+    if(SEPARATE_TESTS)
+        foreach(TEST_SOURCE ${TEST_SOURCES})
+            add_executable(${TEST_SOURCE} ${TEST_SOURCE})
+            target_link_libraries (${TEST_SOURCE} ais ${TEST_LIBS})
+            add_test(${TEST_SOURCE} ${TEST_SOURCE})
+        endforeach()
+    else()
+        add_executable(all_tests ${TEST_SOURCES})
+        target_link_libraries(all_tests ais ${TEST_LIBS})
+        add_test(all_tests all_tests)
+    endif()
+
+endif()
 
 # There must be a new line after each command!

--- a/ais1_2_3_unittest.cpp
+++ b/ais1_2_3_unittest.cpp
@@ -6,7 +6,7 @@
 
 using namespace std;
 
-TEST(TestAis1_2_3,AisMsg) {
+TEST(TestAis123,AisMsg) {
     AisMsg a;
     a.init();
     ASSERT_EQ(AIS_OK, a.get_error());
@@ -17,7 +17,7 @@ import binary
 bv = binary.ais6tobitvec('15Mq4J0P01EREODRv4@74gv00HRq')
 print bv
  */
-TEST(TestAis1_2_3, BitDecoding) {
+TEST(TestAis123, BitDecoding) {
     build_nmea_lookup();
     const string m_str("15Mq4J0P01EREODRv4@74gv00HRq");
     const string bits_expected("000001000101011101111001000100011010000000100000000000000001010101100010010101011111010100100010111110000100010000000111000100101111111110000000000000011000100010111001");
@@ -59,7 +59,7 @@ position:
 	slot_offset:                  n/a
 */
 
-TEST(TestAis1_2_3, AisMsg1) {
+TEST(TestAis123, AisMsg1) {
     const string m_str("AIVDM,1,1,,B,15Mq4J0P01EREODRv4@74gv00HRq,0*72,b003669970,1272412824");
     const string body(nth_field(m_str,5,','));
     ASSERT_STREQ("15Mq4J0P01EREODRv4@74gv00HRq",body.c_str());

--- a/ais8_001_22_unittest.cpp
+++ b/ais8_001_22_unittest.cpp
@@ -45,11 +45,11 @@ const string nth_field(const string &str, const size_t n, const char c) {
 }
 #endif
 
-TEST(EmptyTest, Empty) {
+TEST(ais8dac001fi22, Empty) {
     // FIX: test the empty string case.  What should it do?
 }
 
-TEST(HelperTest, Helper) {
+TEST(ais8dac001fi22, Helper) {
     // Does nth_field work right?
     const string msg_str = "!AIVDM,1,1,,A,81mg=5@0EP:0>H0007P>0<D1<qp400000,0*1D";
     const string body(nth_field(msg_str,5,','));
@@ -58,14 +58,14 @@ TEST(HelperTest, Helper) {
 }
 
 // This is really not working right.  What is going on?
-TEST(PointTest, Point) {
+TEST(ais8dac001fi22, Point) {
     build_nmea_lookup();
 
     // AreaNotice: type=0  start=2011-07-06 00:00:00  duration=60 m  link_id=10  sub-areas: 1
     const string msg_str = "!AIVDM,1,1,,A,81mg=5@0EP:0>H0007P>0<D1<qp400000,0*1D";
     const string body(nth_field(msg_str,5,','));
     //cout << "body: " << body << endl;
-    Ais8_001_22 msg(body.c_str());
+    Ais8_001_22 msg(body.c_str(),0);
     ASSERT_EQ(AIS_OK, msg.get_error());
     //cout << "msg8_1_22: " << endl;
     //msg.print();


### PR DESCRIPTION
You master wouldn't compile on my machine since you never pull the CMake changes I made. Trying again!

Added ctest commands to generate test target in makefile.
Renamed tests to eliminate underscores, since they shouldn't be used according to gtest documentation.
Made test targets optional as well as the choice between a single giant test or smaller individual tests.

Conflicts:

```
CMakeLists.txt
```
