### PR TITLE
Bugfix for segafult in error handling code

### DIFF
--- a/ais.cpp
+++ b/ais.cpp
@@ -60,6 +60,7 @@ string GetBody(const string &nmea_str) {
 const string bits_to_char_tbl="@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     "[\\]^- !\"#$%&`()*+,-./0123456789:;<=>?";
 
+// Note: Needs to be kept in sync with enum AIS_STATUS list in ais.h
 const char * const AIS_STATUS_STRINGS[AIS_STATUS_NUM_CODES] = {
   "AIS_UNINITIALIZED",
   "AIS_OK",
@@ -68,9 +69,12 @@ const char * const AIS_STATUS_STRINGS[AIS_STATUS_NUM_CODES] = {
   "AIS_ERR_BAD_PTR",
   "AIS_ERR_UNKNOWN_MSG_TYPE",
   "AIS_ERR_MSG_NOT_IMPLEMENTED",
-  "AIS_ERR_BAD_MSG_CONTENT",
+  "AIS_ERR_MSG_SUB_NOT_IMPLEMENTED",
   "AIS_ERR_EXPECTED_STRING",
+  "AIS_ERR_BAD_MSG_CONTENT",
   "AIS_ERR_MSG_TOO_LONG",
+  "AIS_ERR_BAD_SUB_MSG",
+  "AIS_ERR_BAD_SUB_SUB_MSG"
 };
 
 bitset<6> Reverse(const bitset<6> &bits) {

--- a/ais.h
+++ b/ais.h
@@ -47,6 +47,7 @@ void BuildNmeaLookup();
 
 static const int MAX_BITS = 1192;
 
+// Note: Needs to be kept in sync with AIS_STATUS_STRINGS list in ais.cpp
 enum AIS_STATUS {
   AIS_UNINITIALIZED,  // Message is not yet completely decoded.
   AIS_OK,


### PR DESCRIPTION
Error handling code segfaulted because of read-past-end-of-list.