### PR TITLE
Type 9: speed over ground off by factor 10

### DIFF
--- a/src/libais/ais9.cpp
+++ b/src/libais/ais9.cpp
@@ -30,7 +30,7 @@ Ais9::Ais9(const char *nmea_payload, const size_t pad)
 
   bs.SeekTo(38);
   alt = bs.ToUnsignedInt(38, 12);
-  sog = bs.ToUnsignedInt(50, 10) / 10.;
+  sog = bs.ToUnsignedInt(50, 10);  // Type 9: Speed over ground is given in knots.
 
   position_accuracy = bs[60];
   position = bs.ToAisPoint(61, 55);


### PR DESCRIPTION
While the speed over ground (sog) is usually encoded in units of deciknots in NMEA sentences, it is encoded in units of knots in message type 9: message type 9 is for SAR planes rather than ships.

Proposed change: Remove unwarrented conversion from deciknots to knots.

NB: I am not sure if the proposed change will create issues with types somewhere down the line (double vs int).