### PR TITLE
Use Travis containers and py.test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ test/data/*.gpsdecode.json
 .eggs
 venv
 venv2
+.cache
+.coverage

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ dist
 .idea/
 venv/
 test/data/*.gpsdecode.json
+.eggs
+venv
+venv2

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,35 @@
+sudo: false
+
 language: python
 
+env:
+  global:
+    - PIP_WHEEL_DIR=$HOME/.cache/pip/wheels
+    - PIP_FIND_LINKS=file://$HOME/.cache/pip/wheels
+
+cache:
+  directories:
+    - ~/.cache/pip
+
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8
+
 python:
-  - "2.7"
-  - "3.4"
+  - 2.7
+  - 3.4
+  - 3.5
 
 before_install:
-  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-  - sudo apt-get update -qq
+  - pip install pip setuptools --upgrade
 
 install:
-  - sudo apt-get install -qq gcc-4.8 g++-4.8
   - CC=g++-4.8 python setup.py install
 
 script:
   - python setup.py test
   - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then (cd src && CC=gcc-4.8 CXX=g++-4.8 make -f Makefile-custom test); fi
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,8 +28,8 @@ before_install:
   - pip install pip setuptools --upgrade
 
 install:
-  - CC=g++-4.8 python setup.py install
+  - CC=g++-4.8 pip install .\[test\] --upgrade
 
 script:
-  - python setup.py test
+  - py.test test ais --cov ais --cov-report term-missing
   - if [[ $TRAVIS_PYTHON_VERSION == '3.4' ]]; then (cd src && CC=gcc-4.8 CXX=g++-4.8 make -f Makefile-custom test); fi

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ import sys
 
 from setuptools import setup, find_packages, Extension
 
-VERSION = open('VERSION').readline().strip()
+with open('VERSION') as f:
+    VERSION = f.readline().strip()
 
 EXTRA_COMPILE_ARGS = []
 if sys.platform in ('darwin', 'linux', 'linux2'):
@@ -65,7 +66,7 @@ setup(name='libais',
           'six'
       ],
       extras_require={
-          'test': ['gpsd_format']
+          'test': ['pytest', 'pytest-cov']
       },
       classifiers=[
           'License :: OSI Approved :: Apache Software License',
@@ -93,5 +94,5 @@ setup(name='libais',
               'libais_stats = ais.stats:main',
           ]
       },
-      test_suite = "test"
+      test_suite="test"
       )


### PR DESCRIPTION
Closes #113 

@schehr Building on [Travis's container infrastructure](http://docs.travis-ci.com/user/workers/container-based-infrastructure/) is faster because you can cache directories between builds.  I changed this mostly to help debug a Travis problem with our pipeline.

Stepping through the container change solved my build problem, so I can roll back one or both of these changes if needed.