### PR TITLE
fix spare data loading

### DIFF
--- a/src/libais/ais.h
+++ b/src/libais/ais.h
@@ -622,6 +622,7 @@ class Ais6_1_5 : public Ais6 {
   bool ai_available;  // TODO(schwehr): AI?  Is this the dac/fi being acked?
   int ai_response;
   int spare;
+  int spare2;
 
   Ais6_1_5(const char *nmea_payload, const size_t pad);
 };

--- a/src/libais/ais6.cpp
+++ b/src/libais/ais6.cpp
@@ -254,7 +254,8 @@ Ais6_1_5::Ais6_1_5(const char *nmea_payload, const size_t pad)
   seq_num = bs.ToUnsignedInt(104, 11);
   ai_available = static_cast<bool>(bs[115]);
   ai_response = bs.ToUnsignedInt(116, 3);
-  spare = bs.ToUnsignedInt(119, 49);
+  spare = bs.ToUnsignedInt(119, 32);
+  spare2 = bs.ToUnsignedInt(151, 17);
 
   assert(bs.GetRemaining() == 0);
 


### PR DESCRIPTION
AisBitset::ToUnsignedInt() has explicit assert that length is not greater than 32.
