### PR TITLE
Enable C++ build, fixed some offset problems

### DIFF
--- a/src/libais/CMakeLists.txt
+++ b/src/libais/CMakeLists.txt
@@ -1,3 +1,9 @@
+# Make sure that assert() is not active in a release build.
+# assert() is used for protocol sanity checks and would stop the program on a protocol error.
+#
+if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
+  add_definitions("-DNDEBUG")
+endif()
 
 add_library(ais 
 ais.cpp

--- a/src/libais/CMakeLists.txt
+++ b/src/libais/CMakeLists.txt
@@ -30,6 +30,8 @@ ais24.cpp
 ais25.cpp
 ais26.cpp
 ais27.cpp
+decode_body.cpp
+vdm.cpp
 )
 
 # Not yet handled:

--- a/src/libais/ais6.cpp
+++ b/src/libais/ais6.cpp
@@ -65,7 +65,6 @@ Ais6_0_0::Ais6_0_0(const char *nmea_payload, const size_t pad)
     status = r;
     return;
   }
-
   bs.SeekTo(88);
   sub_id = bs.ToUnsignedInt(88, 16);
   voltage = bs.ToUnsignedInt(104, 12) / 10.0;
@@ -188,7 +187,7 @@ Ais6_1_3::Ais6_1_3(const char *nmea_payload, const size_t pad)
 
   bs.SeekTo(88);
   req_dac = bs.ToUnsignedInt(88, 10);
-  spare2 = bs.ToUnsignedInt(94, 6);
+  spare2 = bs.ToUnsignedInt(98, 6);
 
   assert(bs.GetRemaining() == 0);
   status = AIS_OK;
@@ -222,7 +221,7 @@ Ais6_1_4::Ais6_1_4(const char *nmea_payload, const size_t pad)
     capabilities[cap_num] = bs[start];
     cap_reserved[cap_num] = bs[start + 1];
   }
-  // spare2 = bs.ToUnsignedInt(226, 6);  // OR NOT
+  spare2 = bs.ToUnsignedInt(226, 6);  // Read the last 6 bits to avoid triggering the assert
   // TODO(schwehr): add in the offset of the dest mmsi
 
   assert(bs.GetRemaining() == 0);


### PR DESCRIPTION
- Completed the list of cpp files in src/libais/CMakeLists.txt to enable the C++ library build for use in C++ applications
- Disabled assert() on release builds (assert() seems to be used on protocol sanity checks, so every invalid message leads to a program termination immediately)
- Fixed some bit stream offsets in ais6.cpp
  (The offset errors were found using the test data from http://www.aishub.net/nmea-sample.php)
