### PR TITLE
cmake install rules for native library

### DIFF
--- a/src/libais/CMakeLists.txt
+++ b/src/libais/CMakeLists.txt
@@ -31,6 +31,17 @@ ais25.cpp
 ais26.cpp
 ais27.cpp
 )
+set_target_properties(ais PROPERTIES PUBLIC_HEADER "ais.h")
+
+include(GNUInstallDirs)
+
+install(TARGETS ais
+  EXPORT LibaisConfig
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
 
 # Not yet handled:
 # ais_py.cpp


### PR DESCRIPTION
Hi Kurt,

I've had a lot of success using libais as a native library from c++ applications; going through python obviously hides a lot of its performance.

Would you be interested in adding something like this code to make it easy for people to install and use libais as a system library?

Thanks,

James