### PR TITLE
spare bits in Ais6_1_5

### DIFF
--- a/src/libais/ais.h
+++ b/src/libais/ais.h
@@ -622,6 +622,7 @@ class Ais6_1_5 : public Ais6 {
   bool ai_available;  // TODO(schwehr): AI?  Is this the dac/fi being acked?
   int ai_response;
   int spare;
+  int spare2;
 
   Ais6_1_5(const char *nmea_payload, const size_t pad);
 };

--- a/src/libais/ais6.cpp
+++ b/src/libais/ais6.cpp
@@ -255,7 +255,7 @@ Ais6_1_5::Ais6_1_5(const char *nmea_payload, const size_t pad)
   ai_available = static_cast<bool>(bs[115]);
   ai_response = bs.ToUnsignedInt(116, 3);
   spare = bs.ToUnsignedInt(119, 32);
-  spare2 = bs.ToUnsignedInt(119, 17);
+  spare2 = bs.ToUnsignedInt(151, 17);
 
   assert(bs.GetRemaining() == 0);
 

--- a/src/libais/ais6.cpp
+++ b/src/libais/ais6.cpp
@@ -255,7 +255,7 @@ Ais6_1_5::Ais6_1_5(const char *nmea_payload, const size_t pad)
   ai_available = static_cast<bool>(bs[115]);
   ai_response = bs.ToUnsignedInt(116, 3);
   spare = bs.ToUnsignedInt(119, 32);
-  spare = bs.ToUnsignedInt(119, 17);
+  spare2 = bs.ToUnsignedInt(119, 17);
 
   assert(bs.GetRemaining() == 0);
 

--- a/src/libais/ais6.cpp
+++ b/src/libais/ais6.cpp
@@ -232,7 +232,7 @@ Ais6_1_4::Ais6_1_4(const char *nmea_payload, const size_t pad)
 // IMO 1371-5 Ack
 Ais6_1_5::Ais6_1_5(const char *nmea_payload, const size_t pad)
     : Ais6(nmea_payload, pad), ack_dac(0), ack_fi(0), seq_num(0),
-      ai_available(false), ai_response(0), spare(0) {
+      ai_available(false), ai_response(0), spare(0), spare2(0) {
   assert(dac == 1);
   assert(fi == 5);
 
@@ -254,7 +254,8 @@ Ais6_1_5::Ais6_1_5(const char *nmea_payload, const size_t pad)
   seq_num = bs.ToUnsignedInt(104, 11);
   ai_available = static_cast<bool>(bs[115]);
   ai_response = bs.ToUnsignedInt(116, 3);
-  spare = bs.ToUnsignedInt(119, 49);
+  spare = bs.ToUnsignedInt(119, 32);
+  spare = bs.ToUnsignedInt(119, 17);
 
   assert(bs.GetRemaining() == 0);
 


### PR DESCRIPTION
The bitset ToUnsignedInt can handle up to 32 bits at a time: its second argument cannot be larger than 32.
In processing ais6.cpp, in Ais6_1_5 ToUnsignedInt is called with a length argument greater than 32, causing a core dump.

This change breaks the reading of the spare bits into two chunks, so as not to exceed 32 bits.