### PR TITLE
Restore CMake-default NDEBUG behaviour

### DIFF
--- a/src/libais/CMakeLists.txt
+++ b/src/libais/CMakeLists.txt
@@ -1,10 +1,3 @@
-# Make sure that assert() is not active in a release build.
-# assert() is used for protocol sanity checks and would stop the program on a protocol error.
-#
-if (NOT CMAKE_BUILD_TYPE MATCHES Debug)
-  add_definitions("-DNDEBUG")
-endif()
-
 add_library(ais 
 ais.cpp
 ais1_2_3.cpp


### PR DESCRIPTION
"CMake defines NDEBUG by default on Release builds. Forcing through a
command line argument in this way also breaks non GCC-style compilers."

This is the only potentially build breaking thing I'm worried about. 

I'll supply another PR to bring `vdm.h` and `decode_body.h` into the CMake fold soon. (CMake is an acquired taste that I'm not so sure I'm glad I've acquired.)