### PR TITLE
Prototype safer AisBitset access wrapper

### DIFF
--- a/src/libais/ais.cpp
+++ b/src/libais/ais.cpp
@@ -234,7 +234,41 @@ const AisPoint AisBitset::ToAisPoint(const size_t start,
   return AisPoint(lng_deg / divisor, lat_deg / divisor);
 }
 
+int AisBitset::GetValue(BitGetter getter) const {
+  assert(getter.target);
+  assert(getter.start + 1 <= GetNumBits());
+  
+  if (getter.start + 1 > GetNumBits()) {
+    return -1;
+  } else {
+    *getter.target = operator[](getter.start);
+    return 0;
+  }
+}
+int AisBitset::GetValue(StringGetter getter) const {
+  assert(getter.target);
+  assert(getter.start + getter.len <= GetNumBits());
+  
+  if (getter.start + getter.len > GetNumBits()) {
+    return -1;
+  } else {
+    *getter.target = ToString(getter.start, getter.len);
+    return 0;
+  }
+}
+int AisBitset::GetValue(UIntGetter getter) const {
+  assert(getter.target);
+  assert(getter.start + getter.len <= GetNumBits());
 
+  if (getter.start + getter.len > GetNumBits()) {
+    return -1;
+  } else {
+    *getter.target = ToUnsignedInt(getter.start, getter.len);
+    return 0;
+  }
+}
+
+    
 // static private
 
 void AisBitset::InitNmeaOrd() {

--- a/src/libais/ais20.cpp
+++ b/src/libais/ais20.cpp
@@ -18,58 +18,71 @@ Ais20::Ais20(const char *nmea_payload, const size_t pad)
     status = AIS_ERR_BAD_BIT_COUNT;  return;
   }
 
+  using UIGet = AisBitset::UIntGetter;
+
   // 160, but must be 6 bit aligned
   assert(message_id == 20);
 
   bits.SeekTo(38);
-  spare = bits.ToUnsignedInt(38, 2);
-
-  offset_1 = bits.ToUnsignedInt(40, 12);
-  num_slots_1 = bits.ToUnsignedInt(52, 4);
-  timeout_1 = bits.ToUnsignedInt(56, 3);
-  incr_1 = bits.ToUnsignedInt(59, 11);
+  status = bits.GetValues(UIGet{&spare,       38,  2},
+                          UIGet{&offset_1,    40, 12},
+                          UIGet{&num_slots_1, 52,  4},
+                          UIGet{&timeout_1,   56,  3},
+                          UIGet{&incr_1,      59, 11});
+  if (!CheckStatus()) return;
 
   if (num_bits == 72) {
-    spare2 = bits.ToUnsignedInt(70, 2);
+    status = bits.GetValues(AisBitset::UIntGetter{&spare2, 70, 2});
+    if (!CheckStatus()) return;
+      
     assert(bits.GetRemaining() == 0);
     status = AIS_OK;
     return;
   }
 
   group_valid_2 = true;
-  offset_2 = bits.ToUnsignedInt(70, 12);
-  num_slots_2 = bits.ToUnsignedInt(82, 4);
-  timeout_2 = bits.ToUnsignedInt(86, 3);
-  incr_2 = bits.ToUnsignedInt(89, 11);
+  status = bits.GetValues(UIGet{&offset_2,    70, 12},
+                          UIGet{&num_slots_2, 82,  4},
+                          UIGet{&timeout_2,   86,  3},
+                          UIGet{&incr_2,      89, 11});
+  if (!CheckStatus()) return;
+  
   // 100 bits for the message
   // 104 is the next byte boundary
   // 108 is the next 6 bit boundary -> 18 characters
   if (num_bits >= 100 && num_bits <=108) {
-    spare2 = bits.ToUnsignedInt(100, bits.GetRemaining());
+    status = bits.GetValues(UIGet{&spare2, 100, bits.GetRemaining()});
+    if (!CheckStatus()) return;
+      
     status = AIS_OK;
     return;
   }
 
   group_valid_3 = true;
-  offset_3 = bits.ToUnsignedInt(100, 12);
-  num_slots_3 = bits.ToUnsignedInt(112, 4);
-  timeout_3 = bits.ToUnsignedInt(116, 3);
-  incr_3 = bits.ToUnsignedInt(119, 11);
+  status = bits.GetValues(UIGet{&offset_3,    100, 12},
+                          UIGet{&num_slots_3, 112,  4},
+                          UIGet{&timeout_3,   116,  3},
+                          UIGet{&incr_3,      119, 11});
+  if (!CheckStatus()) return;
+  
   // 130 bits for the message
   // 136 is the next byte boundary
   // 138 is the next 6 bit boundary -> 23 characters
   if (num_bits >= 130 && num_bits <= 138) {
     // Makes the result 8 bit / 1 byte aligned.
-    spare2 = bits.ToUnsignedInt(130, bits.GetRemaining());
+    status = bits.GetValues(UIGet{&spare2, 130, bits.GetRemaining()});
+    if (!CheckStatus()) return;
+    
     status = AIS_OK;
     return;
   }
 
   group_valid_4 = true;
-  offset_4 = bits.ToUnsignedInt(130, 12);
-  num_slots_4 = bits.ToUnsignedInt(142, 4);
-  timeout_4 = bits.ToUnsignedInt(146, 3);
-  incr_4 = bits.ToUnsignedInt(149, 11);
+  status = bits.GetValues(UIGet{&offset_4,    130, 12},
+                          UIGet{&num_slots_4, 142,  4},
+                          UIGet{&timeout_4,   146,  3},
+                          UIGet{&incr_4,      149, 11});
+  if (!CheckStatus()) return;
 
   spare2 = 0;
 


### PR DESCRIPTION
This is an attempt to improve memory safety in message parsing, by checking whether callers to AisBitset::ToUnsignedInt() etc are reading too far, and returning an error that's easily attached to the Ais object for callers to see. If asserts are enabled, however, it dies on one in the usual way.

This suggestion is particularly prompted by the recent issues raised by fuzzing, so I've converted Ais20 and Ais26 to use the new system, addressing #174 and  #171. If asserts are enabled it continues to die essentially as documented in the issue, or if not then the relevant Ais objects are successfully constructed with status set to AIS_ERR_BAD_BIT_COUNT.

I haven't tested to see whether this affects performance yet - I'm happy to have a look if there's a standard project method based on public data. If there's significant degradation then I think it's possible to do something very similar statically, using the same number of branches as currently exist. That would be an ugly mess of templates, however.