### PR TITLE
Fix memory leaks while handling messages 6, 8 and 24

### DIFF
--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -782,6 +782,7 @@ ais6_to_pydict(const char *nmea_payload, const size_t pad) {
                  msg.dac,
                  msg.fi,
                  AIS_STATUS_STRINGS[status]);
+    Py_DECREF(dict);
     return nullptr;
   }
 
@@ -2119,6 +2120,7 @@ ais8_to_pydict(const char *nmea_payload, const size_t pad) {
   if (status != AIS_OK) {
     PyErr_Format(ais_py_exception, "Ais8: %s",
                  AIS_STATUS_STRINGS[status]);
+    Py_DECREF(dict);
     return nullptr;
   }
 
@@ -2634,6 +2636,7 @@ ais24_to_pydict(const char *nmea_payload, const size_t pad) {
   default:
     // status = AIS_ERR_BAD_MSG_CONTENT;
     // TODO(schwehr): setup python exception
+    Py_DECREF(dict);
     return nullptr;
   }
 


### PR DESCRIPTION
Fix rather rapid memory leaks caused by Python objects allocated in the handling of messages 6, 8 and 24 not being freed because of missing Py_DECREF calls when encountering an error and returning nullptr.