### PR TITLE
AIS backtick bug fix.

### DIFF
--- a/src/libais/ais_bitset.cpp
+++ b/src/libais/ais_bitset.cpp
@@ -187,6 +187,6 @@ bool AisBitset::nmea_ord_initialized_ = false;
 bitset<6> AisBitset::nmea_ord_[128];
 // For decoding str bits inside of a binary message.
 const char AisBitset::bits_to_char_tbl_[] = "@ABCDEFGHIJKLMNOPQRSTUVWXYZ"
-    "[\\]^- !\"#$%&`()*+,-./0123456789:;<=>?";
+    "[\\]^- !\"#$%&\'()*+,-./0123456789:;<=>?";
 
 }  // namespace libais


### PR DESCRIPTION
Replaces ais bitset backtick with escaped single-quote in accordance with 6bit ASCII spec (Dec. 39 should be ' but was `).