### PR TITLE
Fix memory leaks in python binding

### DIFF
--- a/src/libais/ais.h
+++ b/src/libais/ais.h
@@ -12,10 +12,12 @@
 #include <string>
 #include <iostream>
 #include <vector>
+#include <memory>
 
 using std::bitset;
 using std::ostream;
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 #define LIBAIS_VERSION_MAJOR 0
@@ -1136,7 +1138,7 @@ class Ais8_1_22_SubArea {
   virtual ~Ais8_1_22_SubArea() {}
 };
 
-Ais8_1_22_SubArea*
+unique_ptr<Ais8_1_22_SubArea>
 ais8_1_22_subarea_factory(const AisBitset &bs,
                           const size_t offset);
 
@@ -1239,10 +1241,9 @@ class Ais8_1_22 : public Ais8 {
   int duration_minutes;  // Time from the start until the notice expires.
 
   // 1 or more sub messages
-  vector<Ais8_1_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_1_22_SubArea>> sub_areas;
 
   Ais8_1_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_1_22();
 };
 ostream& operator<< (ostream& o, Ais8_1_22 const& msg);
 
@@ -1762,7 +1763,7 @@ class Ais8_366_22_SubArea {
     virtual ~Ais8_366_22_SubArea() { }
 };
 
-Ais8_366_22_SubArea*
+unique_ptr<Ais8_366_22_SubArea>
 ais8_366_22_subarea_factory(const AisBitset &bs,
                             const size_t offset);
 
@@ -1861,10 +1862,9 @@ class Ais8_366_22 : public Ais8 {
   int duration_minutes;  // Time from the start until the notice expires
   // 1 or more sub messages
 
-  vector<Ais8_366_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_366_22_SubArea>> sub_areas;
 
   Ais8_366_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_366_22();
 };
 ostream& operator<< (ostream& o, Ais8_366_22 const& msg);
 
@@ -1888,7 +1888,7 @@ class Ais8_367_22_SubArea {
   virtual ~Ais8_367_22_SubArea() { }
 };
 
-Ais8_367_22_SubArea*
+unique_ptr<Ais8_367_22_SubArea>
 ais8_367_22_subarea_factory(const AisBitset &bs,
                             const size_t offset);
 
@@ -1972,10 +1972,9 @@ class Ais8_367_22 : public Ais8 {
   int duration_minutes;
   int spare2;
 
-  vector<Ais8_367_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_367_22_SubArea>> sub_areas;
 
   Ais8_367_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_367_22();
 };
 ostream& operator<< (ostream& o, Ais8_367_22 const& msg);
 

--- a/src/libais/ais8_1_22.cpp
+++ b/src/libais/ais8_1_22.cpp
@@ -233,7 +233,7 @@ Ais8_1_22_Text::Ais8_1_22_Text(const AisBitset &bits,
 }
 
 // Call the appropriate constructor
-Ais8_1_22_SubArea*
+std::unique_ptr<Ais8_1_22_SubArea>
 ais8_1_22_subarea_factory(const AisBitset &bits,
                             const size_t offset) {
   const Ais8_1_22_AreaShapeEnum area_shape =
@@ -241,17 +241,17 @@ ais8_1_22_subarea_factory(const AisBitset &bits,
 
   switch (area_shape) {
   case AIS8_1_22_SHAPE_CIRCLE:
-    return new Ais8_1_22_Circle(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Circle(bits, offset + 3));
   case AIS8_1_22_SHAPE_RECT:
-    return new Ais8_1_22_Rect(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Rect(bits, offset + 3));
   case AIS8_1_22_SHAPE_SECTOR:
-    return new Ais8_1_22_Sector(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Sector(bits, offset + 3));
   case AIS8_1_22_SHAPE_POLYLINE:
-    return new Ais8_1_22_Polyline(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Polyline(bits, offset + 3));
   case AIS8_1_22_SHAPE_POLYGON:
-    return new Ais8_1_22_Polygon(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Polygon(bits, offset + 3));
   case AIS8_1_22_SHAPE_TEXT:
-    return new Ais8_1_22_Text(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Text(bits, offset + 3));
   case AIS8_1_22_SHAPE_RESERVED_6:  // FALLTHROUGH
   case AIS8_1_22_SHAPE_RESERVED_7:  // FALLTHROUGH
     // Keep area==0 to indicate error.
@@ -261,7 +261,7 @@ ais8_1_22_subarea_factory(const AisBitset &bits,
   default:
     assert(false);
   }
-  return nullptr;
+  return {};
 }
 
 
@@ -299,9 +299,9 @@ Ais8_1_22::Ais8_1_22(const char *nmea_payload, const size_t pad)
   const int num_sub_areas = static_cast<int>(floor((num_bits - 111)/87.));
   for (int sub_area_idx = 0; sub_area_idx < num_sub_areas; sub_area_idx++) {
     const size_t start = 111 + AIS8_1_22_SUBAREA_SIZE*sub_area_idx;
-    Ais8_1_22_SubArea *sub_area = ais8_1_22_subarea_factory(bits, start);
+    std::unique_ptr<Ais8_1_22_SubArea> sub_area = ais8_1_22_subarea_factory(bits, start);
     if (sub_area) {
-      sub_areas.push_back(sub_area);
+      sub_areas.push_back(std::move(sub_area));
     } else {
       status = AIS_ERR_BAD_SUB_SUB_MSG;
     }
@@ -314,14 +314,6 @@ Ais8_1_22::Ais8_1_22(const char *nmea_payload, const size_t pad)
   // TODO(schwehr): Add assert(bits.GetRemaining() == 0);
   if (status == AIS_UNINITIALIZED)
     status = AIS_OK;
-}
-
-// TODO(schwehr): Use unique_ptr to manage memory.
-Ais8_1_22::~Ais8_1_22() {
-  for (size_t i = 0; i < sub_areas.size(); i++) {
-    delete sub_areas[i];
-    sub_areas[i] = nullptr;
-  }
 }
 
 }  // namespace libais

--- a/src/libais/ais8_366_22.cpp
+++ b/src/libais/ais8_366_22.cpp
@@ -169,10 +169,10 @@ Ais8_366_22::Ais8_366_22(const char *nmea_payload, const size_t pad)
 
   const int num_sub_areas = static_cast<int>(floor((num_bits - 111)/90.));
   for (int area_idx = 0; area_idx < num_sub_areas; area_idx++) {
-    Ais8_366_22_SubArea *area =
+    std::unique_ptr<Ais8_366_22_SubArea> area =
         ais8_366_22_subarea_factory(bits, 111 + 90*area_idx);
     if (area) {
-      sub_areas.push_back(area);
+      sub_areas.push_back(std::move(area));
     } else {
       status = AIS_ERR_BAD_SUB_SUB_MSG;
       return;
@@ -181,16 +181,6 @@ Ais8_366_22::Ais8_366_22(const char *nmea_payload, const size_t pad)
 
   assert(bits.GetRemaining() == 0);
   status = AIS_OK;
-}
-
-Ais8_366_22::~Ais8_366_22() {
-  // Switch to unique_ptr.
-  for (size_t i = 0; i < sub_areas.size(); i++) {
-    delete sub_areas[i];
-#ifndef NDEBUG
-    sub_areas[i] = NULL;
-#endif
-  }
 }
 
 // Lookup table for the scale factors to decode the length / distance fields.
@@ -270,7 +260,7 @@ Ais8_366_22_Text::Ais8_366_22_Text(const AisBitset &bits,
 }
 
 // Call the appropriate constructor
-Ais8_366_22_SubArea *
+std::unique_ptr<Ais8_366_22_SubArea>
 ais8_366_22_subarea_factory(const AisBitset &bits,
                             const size_t offset) {
   const Ais8_366_22_AreaShapeEnum area_shape =
@@ -278,17 +268,17 @@ ais8_366_22_subarea_factory(const AisBitset &bits,
 
   switch (area_shape) {
   case AIS8_366_22_SHAPE_CIRCLE:
-    return new Ais8_366_22_Circle(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Circle(bits, offset));
   case AIS8_366_22_SHAPE_RECT:
-    return new Ais8_366_22_Rect(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Rect(bits, offset));
   case AIS8_366_22_SHAPE_SECTOR:
-    return new Ais8_366_22_Sector(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Sector(bits, offset));
   case AIS8_366_22_SHAPE_POLYLINE:
-    return new Ais8_366_22_Polyline(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Polyline(bits, offset));
   case AIS8_366_22_SHAPE_POLYGON:
-    return new Ais8_366_22_Polygon(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Polygon(bits, offset));
   case AIS8_366_22_SHAPE_TEXT:
-    return new Ais8_366_22_Text(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Text(bits, offset));
   case AIS8_366_22_SHAPE_RESERVED_6:  // FALLTHROUGH
   case AIS8_366_22_SHAPE_RESERVED_7:  // FALLTHROUGH
     // Leave area as 0 to indicate error
@@ -298,7 +288,7 @@ ais8_366_22_subarea_factory(const AisBitset &bits,
   default:
     assert(false);
   }
-  return nullptr;
+  return {};
 }
 
 }  // namespace libais

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -755,6 +755,7 @@ ais6_to_pydict(const char *nmea_payload, const size_t pad) {
   }
 
   if (status != AIS_OK) {
+    Py_DECREF(dict);
     PyErr_Format(ais_py_exception,
                  "Ais6: DAC:FI not known.  6:%d:%d %s",
                  msg.dac,
@@ -2126,6 +2127,7 @@ ais8_to_pydict(const char *nmea_payload, const size_t pad) {
   }
 
   if (status != AIS_OK) {
+    Py_DECREF(dict);
     PyErr_Format(ais_py_exception, "Ais8: %s",
                  AIS_STATUS_STRINGS[status]);
     return nullptr;
@@ -2641,6 +2643,7 @@ ais24_to_pydict(const char *nmea_payload, const size_t pad) {
   default:
     // status = AIS_ERR_BAD_MSG_CONTENT;
     // TODO(schwehr): setup python exception
+    Py_DECREF(dict);
     return nullptr;
   }
 

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -65,57 +65,42 @@ enum AIS_FI {
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const long val) {  // NOLINT
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyLong_FromLong(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const int val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyLong_FromLong(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const unsigned int val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyLong_FromLong(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const string &val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyUnicode_FromString(val.c_str());
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const char *val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyUnicode_FromString(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
@@ -134,37 +119,28 @@ DictSafeSetItem(PyObject *dict, const string &key, const bool val) {
 #else
 void
 DictSafeSetItem(PyObject *dict, const string &key, const bool val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
-  assert(key_obj);
   if (val) {
-    PyDict_SetItem(dict, key_obj, Py_True);
+    PyDict_SetItemString(dict, key.c_str(), Py_True);
   } else {
-    PyDict_SetItem(dict, key_obj, Py_False);
+    PyDict_SetItemString(dict, key.c_str(), Py_False);
   }
-  Py_DECREF(key_obj);
 }
 #endif
 
 void
 DictSafeSetItem(PyObject *dict, const string &key, const float val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyFloat_FromDouble(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
 // Python Floats are IEE-754 double precision.
 void
 DictSafeSetItem(PyObject *dict, const string &key, const double val) {
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
   PyObject *val_obj = PyFloat_FromDouble(val);
-  assert(key_obj);
   assert(val_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
   Py_DECREF(val_obj);
 }
 
@@ -180,10 +156,7 @@ DictSafeSetItem(PyObject *dict, const string &key, PyObject *val_obj) {
   // When we need to add dictionaries and such to a dictionary
   assert(dict);
   assert(val_obj);
-  PyObject *key_obj = PyUnicode_FromString(key.c_str());
-  assert(key_obj);
-  PyDict_SetItem(dict, key_obj, val_obj);
-  Py_DECREF(key_obj);
+  PyDict_SetItemString(dict, key.c_str(), val_obj);
 }
 
 
@@ -536,7 +509,7 @@ ais6_1_14_append_pydict(const char *nmea_payload, PyObject *dict,
     DictSafeSetItem(window, "cur_speed", msg.windows[w_num].cur_speed);
     PyList_SetItem(window_list, w_num, window);
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("windows"), window_list);
+  PyDict_SetItemString(dict, "windows", window_list);
 
   return AIS_OK;
 }
@@ -639,7 +612,7 @@ ais6_1_25_append_pydict(const char *nmea_payload, PyObject *dict,
       DictSafeSetItem(cargo, "marpol_cat", msg.cargos[cargo_num].marpol_cat);
     PyList_SetItem(cargo_list, cargo_num, cargo);
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("cargos"), cargo_list);
+  PyDict_SetItemString(dict, "cargos", cargo_list);
 
   return AIS_OK;
 }
@@ -677,7 +650,7 @@ ais6_1_32_append_pydict(const char *nmea_payload, PyObject *dict,
     DictSafeSetItem(win, "cur_speed", msg.windows[win_num].cur_speed);
     PyList_SetItem(window_list, win_num, win);
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("windows"), window_list);
+  PyDict_SetItemString(dict, "windows", window_list);
 
   return AIS_OK;
 }
@@ -808,7 +781,7 @@ ais7_13_to_pydict(const char *nmea_payload, const size_t pad) {
     PyTuple_SetItem(tuple, 1, PyLong_FromLong(msg.seq_num[i]));  // Steals ref
     PyList_SetItem(list, i, tuple);  // Steals ref
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("acks"), list);
+  PyDict_SetItemString(dict, "acks", list);
   Py_DECREF(list);
   return dict;
 }
@@ -983,7 +956,7 @@ ais8_1_17_append_pydict(const char *nmea_payload, PyObject *dict,
     DictSafeSetItem(target, "sog", msg.targets[target_num].sog);
     PyList_SetItem(target_list, target_num, target);
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("targets"), target_list);
+  PyDict_SetItemString(dict, "targets", target_list);
 
   return AIS_OK;
 }
@@ -1580,7 +1553,7 @@ ais8_1_27_append_pydict(const char *nmea_payload, PyObject *dict,
         waypoint, 1, PyFloat_FromDouble(msg.waypoints[point_num].lat_deg));
     PyList_SetItem(waypoint_list, point_num, waypoint);
   }
-  PyDict_SetItem(dict, PyUnicode_FromString("waypoints"), waypoint_list);
+  PyDict_SetItemString(dict, "waypoints", waypoint_list);
 
   return AIS_OK;
 }
@@ -2506,9 +2479,7 @@ ais20_to_pydict(const char *nmea_payload, const size_t pad) {
     PyList_SetItem(list, 3, reservation);
   }
 
-  PyObject * reservations = PyUnicode_FromString("reservations");
-  PyDict_SetItem(dict, reservations, list);
-  Py_DECREF(reservations);
+  PyDict_SetItemString(dict, "reservations", list);
   Py_DECREF(list);
 
   return dict;

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -418,7 +418,9 @@ ais6_1_4_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(res_list, cap_num, res);
   }
   DictSafeSetItem(dict, "capabilities", cap_list);
+  Py_DECREF(cap_list);
   DictSafeSetItem(dict, "cap_reserved", res_list);
+  Py_DECREF(res_list);
   DictSafeSetItem(dict, "spare2", msg.spare2);
   DictSafeSetItem(dict, "spare3", msg.spare2);
   DictSafeSetItem(dict, "spare4", msg.spare2);
@@ -510,6 +512,7 @@ ais6_1_14_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(window_list, w_num, window);
   }
   PyDict_SetItemString(dict, "windows", window_list);
+  Py_DECREF(window_list);
 
   return AIS_OK;
 }
@@ -569,6 +572,7 @@ ais6_1_20_append_pydict(const char *nmea_payload, PyObject *dict,
       PyList_SetItem(serv_list, serv_num, serv);
     }
     DictSafeSetItem(dict, "services", serv_list);
+    Py_DECREF(serv_list);
   }
   DictSafeSetItem(dict, "name", msg.name);
   DictSafeSetItem(dict, "x", "y", msg.position);
@@ -613,6 +617,7 @@ ais6_1_25_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(cargo_list, cargo_num, cargo);
   }
   PyDict_SetItemString(dict, "cargos", cargo_list);
+  Py_DECREF(cargo_list);
 
   return AIS_OK;
 }
@@ -651,6 +656,7 @@ ais6_1_32_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(window_list, win_num, win);
   }
   PyDict_SetItemString(dict, "windows", window_list);
+  Py_DECREF(window_list);
 
   return AIS_OK;
 }
@@ -957,6 +963,7 @@ ais8_1_17_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(target_list, target_num, target);
   }
   PyDict_SetItemString(dict, "targets", target_list);
+  Py_DECREF(target_list);
 
   return AIS_OK;
 }
@@ -1183,6 +1190,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
 
         DictSafeSetItem(sub_area, "angles", angle_list);
         DictSafeSetItem(sub_area, "dists_m", dist_list);
+        Py_DECREF(angle_list);
+        Py_DECREF(dist_list);
 
         // TODO(schwehr): spare?
         PyList_SetItem(sub_area_list, i, sub_area);
@@ -1210,6 +1219,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
 
         DictSafeSetItem(sub_area, "angles", angle_list);
         DictSafeSetItem(sub_area, "dists_m", dist_list);
+        Py_DECREF(angle_list);
+        Py_DECREF(dist_list);
 
         // TODO(schwehr): spare?
         PyList_SetItem(sub_area_list, i, sub_area);
@@ -1236,6 +1247,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
     }
   }
   DictSafeSetItem(dict, "sub_areas", sub_area_list);
+  Py_DECREF(sub_area_list);
 
   return AIS_OK;
 }
@@ -1270,7 +1282,10 @@ ais8_1_24_append_pydict(const char *nmea_payload, PyObject *dict,
     PyObject *solas = PyLong_FromLong(msg.solas_status[solas_num]);
     PyList_SetItem(solas_list, solas_num, solas);
   }
+  DictSafeSetItem(dict, "port_list", port_list);
+  Py_DECREF(port_list);
   DictSafeSetItem(dict, "solas", solas_list);
+  Py_DECREF(solas_list);
   DictSafeSetItem(dict, "ice_class", msg.ice_class);
   DictSafeSetItem(dict, "shaft_power", msg.shaft_power);
   DictSafeSetItem(dict, "vhf", msg.vhf);
@@ -1400,6 +1415,7 @@ ais8_1_26_append_pydict(const char *nmea_payload, PyObject *dict,
           DictSafeSetItem(curr_dict, "depth", rpt->currents[idx].depth);
           PyList_SetItem(curr_list, idx, curr_dict);
         }
+        Py_DECREF(curr_list);
       }
       break;
     case AIS8_1_26_SENSOR_CURR_3D:
@@ -1420,6 +1436,7 @@ ais8_1_26_append_pydict(const char *nmea_payload, PyObject *dict,
           DictSafeSetItem(curr_dict, "up", rpt->currents[idx].up);
           DictSafeSetItem(curr_dict, "depth", rpt->currents[idx].depth);
         }
+        Py_DECREF(curr_list);
       }
       break;
     case AIS8_1_26_SENSOR_HORZ_FLOW:
@@ -1439,6 +1456,7 @@ ais8_1_26_append_pydict(const char *nmea_payload, PyObject *dict,
           DictSafeSetItem(curr_dict, "dir", rpt->currents[idx].dir);
           DictSafeSetItem(curr_dict, "level", rpt->currents[idx].level);
         }
+        Py_DECREF(curr_list);
       }
       break;
     case AIS8_1_26_SENSOR_SEA_STATE:
@@ -1517,6 +1535,7 @@ ais8_1_26_append_pydict(const char *nmea_payload, PyObject *dict,
       {}  // TODO(schwehr): mark a bad sensor type or raise exception
     }
   }
+  Py_DECREF(rpt_list);
 
   return AIS_OK;
 }
@@ -1554,6 +1573,7 @@ ais8_1_27_append_pydict(const char *nmea_payload, PyObject *dict,
     PyList_SetItem(waypoint_list, point_num, waypoint);
   }
   PyDict_SetItemString(dict, "waypoints", waypoint_list);
+  Py_DECREF(waypoint_list);
 
   return AIS_OK;
 }
@@ -1779,11 +1799,13 @@ ais8_200_24_append_pydict(const char *nmea_payload, PyObject *dict,
   for (size_t i = 0; i < 4; i++)
     PyList_SetItem(id_list, i, PyLong_FromLong(msg.gauge_ids[i]));
   DictSafeSetItem(dict, "gauge_ids", id_list);
+  Py_DECREF(id_list);
 
   PyObject *level_list = PyList_New(4);
   for (size_t i = 0; i < 4; i++)
     PyList_SetItem(level_list, i, PyFloat_FromDouble(msg.levels[i]));
   DictSafeSetItem(dict, "levels", level_list);
+  Py_DECREF(level_list);
 
   return AIS_OK;
 }
@@ -1835,6 +1857,7 @@ ais8_200_55_append_pydict(const char *nmea_payload, PyObject *dict,
   for (size_t i = 0; i < 3; i++)
     PyList_SetItem(spare2_list, 0,  PyLong_FromLong(msg.spare2[i]));
   DictSafeSetItem(dict, "spare2", spare2_list);
+  Py_DECREF(spare2_list);
 
   return AIS_OK;
 }
@@ -1946,6 +1969,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
 
         DictSafeSetItem(sub_area, "angles", angle_list);
         DictSafeSetItem(sub_area, "dists_m", dist_list);
+        Py_DECREF(angle_list);
+        Py_DECREF(dist_list);
 
         PyList_SetItem(sub_area_list, i, sub_area);
       }
@@ -1972,6 +1997,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
     }
   }
   DictSafeSetItem(dict, "sub_areas", sub_area_list);
+  Py_DECREF(sub_area_list);
 }
 
 // AIS Binary broadcast messages.  There will be a huge number of subtypes

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -1134,7 +1134,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Circle *c =
-            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1153,7 +1154,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Rect *c =
-            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1171,7 +1173,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Sector *c =
-            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1189,7 +1192,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polyline *polyline =
-            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
+        assert(polyline != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYLINE);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polyline");
@@ -1215,7 +1219,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polygon *polygon =
-            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
+        assert(polygon != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYGON);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polygon");
@@ -1242,7 +1247,9 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_1_22_Text *text =
-            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
+        assert(text != nullptr);
+
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 
@@ -1887,7 +1894,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Circle *c =
-            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1905,7 +1913,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Rect *c =
-            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1923,7 +1932,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Sector *c =
-            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1942,7 +1952,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Poly *poly =
-            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
+        assert(poly != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", msg.sub_areas[i]->getType());
         if (msg.sub_areas[i]->getType() == AIS8_366_22_SHAPE_POLYLINE)
@@ -1971,7 +1982,9 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_367_22_Text *text =
-            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
+        assert(text != nullptr);
+
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -1134,7 +1134,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Circle *c =
-            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1153,7 +1153,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Rect *c =
-            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1171,7 +1171,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Sector *c =
-            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1189,7 +1189,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polyline *polyline =
-            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYLINE);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polyline");
@@ -1215,7 +1215,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polygon *polygon =
-            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYGON);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polygon");
@@ -1242,7 +1242,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_1_22_Text *text =
-            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 
@@ -1887,7 +1887,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Circle *c =
-            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1905,7 +1905,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Rect *c =
-            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1923,7 +1923,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Sector *c =
-            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1942,7 +1942,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Poly *poly =
-            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", msg.sub_areas[i]->getType());
         if (msg.sub_areas[i]->getType() == AIS8_366_22_SHAPE_POLYLINE)
@@ -1971,7 +1971,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_367_22_Text *text =
-            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -410,7 +410,6 @@ ais6_1_4_append_pydict(const char *nmea_payload, PyObject *dict,
   PyObject *cap_list = PyList_New(kNumFI);
   PyObject *res_list = PyList_New(kNumFI);
   for (size_t cap_num = 0; cap_num < kNumFI; cap_num++) {
-    // TODO(schwehr): memory leak?
     PyObject *cap = PyLong_FromLong(long(msg.capabilities[cap_num]));  // NOLINT
     PyList_SetItem(cap_list, cap_num, cap);
 
@@ -1272,10 +1271,8 @@ ais8_1_24_append_pydict(const char *nmea_payload, PyObject *dict,
   DictSafeSetItem(dict, "last_port", msg.last_port);
 
   PyObject *port_list = PyList_New(2);
-  PyObject *port0 = PyUnicode_FromString(msg.next_ports[0].c_str());
-  PyObject *port1 = PyUnicode_FromString(msg.next_ports[0].c_str());
-  PyList_SetItem(port_list, 0, port0); Py_DECREF(port0);
-  PyList_SetItem(port_list, 1, port1); Py_DECREF(port1);
+  PyList_SetItem(port_list, 0, PyUnicode_FromString(msg.next_ports[0].c_str()));
+  PyList_SetItem(port_list, 1, PyUnicode_FromString(msg.next_ports[0].c_str()));
 
   PyObject *solas_list = PyList_New(26);
   for (size_t solas_num = 0; solas_num < 26; solas_num++) {

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -2642,8 +2642,9 @@ ais24_to_pydict(const char *nmea_payload, const size_t pad) {
   case 3:  // FALLTHROUGH - not yet defined by ITU
   default:
     // status = AIS_ERR_BAD_MSG_CONTENT;
-    // TODO(schwehr): setup python exception
     Py_DECREF(dict);
+    PyErr_Format(ais_py_exception, "Ais24: unknown part_num %d",
+                 msg.part_num);
     return nullptr;
   }
 


### PR DESCRIPTION
Hi,

We noticed memory leaks in `libais` that became to be problematic for us. Here is a series of patches that fixes those.

While looking at memory issues, I’ve also changed few manually managed raw pointers (`new` / `delete`) and changed them to `std::unique_ptr` (this is the first commit). I also changed some probably incorrect uses of `reinterpred_cast` to `dynamic_cast` (second commit).

I finally got to the crux of the problem which was in `ais_py.cpp`. This is where the rest of the patch series does changes:

- `PyDict_SetItem` was sometimes miss-used. The pattern was:

```c
PyDict_SetItem(dict, PyUnicode_FromString("foo"), foo);
```

where it should have been:

```c
PyObject *foo_key = PyUnicode_FromString("foo");
assert(foo_key);
PyDict_SetItem(dict, foo_key, foo);
Py_DECREF(foo_key);
```

An equivalent solution us to use `PyDict_SetItemString`:

```c
PyDict_SetItemString(dict, "foo", foo);
```

which is equivalent. This is done in patch 3.

- Few lists where created, populated and not `Py_DECREF`ed. This is changed in patch 4.
- Some erroneous cases forget to `Py_DECREF` the dict being created before raising an exception. This is changed in patch 5.
- `PyList_SetItem` steals the reference of its argument. Some code did try to `Py_DECREF` the argument after calling `PyList_SetItem`. This is handled in patch 6.
- Finally, we now raise an exception when failing to parse a 24 essage. This is done in patch 7.

If necessary, I can re-arrange patches / drop the 2 first ones if they do not belong in this PR.