### PR TITLE
Use uniqueptr and dynamic cast

### DIFF
--- a/src/libais/ais.h
+++ b/src/libais/ais.h
@@ -12,10 +12,12 @@
 #include <string>
 #include <iostream>
 #include <vector>
+#include <memory>
 
 using std::bitset;
 using std::ostream;
 using std::string;
+using std::unique_ptr;
 using std::vector;
 
 #define LIBAIS_VERSION_MAJOR 0
@@ -1136,7 +1138,7 @@ class Ais8_1_22_SubArea {
   virtual ~Ais8_1_22_SubArea() {}
 };
 
-Ais8_1_22_SubArea*
+unique_ptr<Ais8_1_22_SubArea>
 ais8_1_22_subarea_factory(const AisBitset &bs,
                           const size_t offset);
 
@@ -1239,10 +1241,9 @@ class Ais8_1_22 : public Ais8 {
   int duration_minutes;  // Time from the start until the notice expires.
 
   // 1 or more sub messages
-  vector<Ais8_1_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_1_22_SubArea>> sub_areas;
 
   Ais8_1_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_1_22();
 };
 ostream& operator<< (ostream& o, Ais8_1_22 const& msg);
 
@@ -1762,7 +1763,7 @@ class Ais8_366_22_SubArea {
     virtual ~Ais8_366_22_SubArea() { }
 };
 
-Ais8_366_22_SubArea*
+unique_ptr<Ais8_366_22_SubArea>
 ais8_366_22_subarea_factory(const AisBitset &bs,
                             const size_t offset);
 
@@ -1861,10 +1862,9 @@ class Ais8_366_22 : public Ais8 {
   int duration_minutes;  // Time from the start until the notice expires
   // 1 or more sub messages
 
-  vector<Ais8_366_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_366_22_SubArea>> sub_areas;
 
   Ais8_366_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_366_22();
 };
 ostream& operator<< (ostream& o, Ais8_366_22 const& msg);
 
@@ -1888,7 +1888,7 @@ class Ais8_367_22_SubArea {
   virtual ~Ais8_367_22_SubArea() { }
 };
 
-Ais8_367_22_SubArea*
+unique_ptr<Ais8_367_22_SubArea>
 ais8_367_22_subarea_factory(const AisBitset &bs,
                             const size_t offset);
 
@@ -1972,10 +1972,9 @@ class Ais8_367_22 : public Ais8 {
   int duration_minutes;
   int spare2;
 
-  vector<Ais8_367_22_SubArea *> sub_areas;
+  vector<unique_ptr<Ais8_367_22_SubArea>> sub_areas;
 
   Ais8_367_22(const char *nmea_payload, const size_t pad);
-  ~Ais8_367_22();
 };
 ostream& operator<< (ostream& o, Ais8_367_22 const& msg);
 

--- a/src/libais/ais8_1_22.cpp
+++ b/src/libais/ais8_1_22.cpp
@@ -233,7 +233,7 @@ Ais8_1_22_Text::Ais8_1_22_Text(const AisBitset &bits,
 }
 
 // Call the appropriate constructor
-Ais8_1_22_SubArea*
+std::unique_ptr<Ais8_1_22_SubArea>
 ais8_1_22_subarea_factory(const AisBitset &bits,
                             const size_t offset) {
   const Ais8_1_22_AreaShapeEnum area_shape =
@@ -241,17 +241,17 @@ ais8_1_22_subarea_factory(const AisBitset &bits,
 
   switch (area_shape) {
   case AIS8_1_22_SHAPE_CIRCLE:
-    return new Ais8_1_22_Circle(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Circle(bits, offset + 3));
   case AIS8_1_22_SHAPE_RECT:
-    return new Ais8_1_22_Rect(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Rect(bits, offset + 3));
   case AIS8_1_22_SHAPE_SECTOR:
-    return new Ais8_1_22_Sector(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Sector(bits, offset + 3));
   case AIS8_1_22_SHAPE_POLYLINE:
-    return new Ais8_1_22_Polyline(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Polyline(bits, offset + 3));
   case AIS8_1_22_SHAPE_POLYGON:
-    return new Ais8_1_22_Polygon(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Polygon(bits, offset + 3));
   case AIS8_1_22_SHAPE_TEXT:
-    return new Ais8_1_22_Text(bits, offset + 3);
+    return std::unique_ptr<Ais8_1_22_SubArea>(new Ais8_1_22_Text(bits, offset + 3));
   case AIS8_1_22_SHAPE_RESERVED_6:  // FALLTHROUGH
   case AIS8_1_22_SHAPE_RESERVED_7:  // FALLTHROUGH
     // Keep area==0 to indicate error.
@@ -261,7 +261,7 @@ ais8_1_22_subarea_factory(const AisBitset &bits,
   default:
     assert(false);
   }
-  return nullptr;
+  return {};
 }
 
 
@@ -299,9 +299,9 @@ Ais8_1_22::Ais8_1_22(const char *nmea_payload, const size_t pad)
   const int num_sub_areas = static_cast<int>(floor((num_bits - 111)/87.));
   for (int sub_area_idx = 0; sub_area_idx < num_sub_areas; sub_area_idx++) {
     const size_t start = 111 + AIS8_1_22_SUBAREA_SIZE*sub_area_idx;
-    Ais8_1_22_SubArea *sub_area = ais8_1_22_subarea_factory(bits, start);
+    std::unique_ptr<Ais8_1_22_SubArea> sub_area = ais8_1_22_subarea_factory(bits, start);
     if (sub_area) {
-      sub_areas.push_back(sub_area);
+      sub_areas.push_back(std::move(sub_area));
     } else {
       status = AIS_ERR_BAD_SUB_SUB_MSG;
     }
@@ -314,14 +314,6 @@ Ais8_1_22::Ais8_1_22(const char *nmea_payload, const size_t pad)
   // TODO(schwehr): Add assert(bits.GetRemaining() == 0);
   if (status == AIS_UNINITIALIZED)
     status = AIS_OK;
-}
-
-// TODO(schwehr): Use unique_ptr to manage memory.
-Ais8_1_22::~Ais8_1_22() {
-  for (size_t i = 0; i < sub_areas.size(); i++) {
-    delete sub_areas[i];
-    sub_areas[i] = nullptr;
-  }
 }
 
 }  // namespace libais

--- a/src/libais/ais8_366_22.cpp
+++ b/src/libais/ais8_366_22.cpp
@@ -169,10 +169,10 @@ Ais8_366_22::Ais8_366_22(const char *nmea_payload, const size_t pad)
 
   const int num_sub_areas = static_cast<int>(floor((num_bits - 111)/90.));
   for (int area_idx = 0; area_idx < num_sub_areas; area_idx++) {
-    Ais8_366_22_SubArea *area =
+    std::unique_ptr<Ais8_366_22_SubArea> area =
         ais8_366_22_subarea_factory(bits, 111 + 90*area_idx);
     if (area) {
-      sub_areas.push_back(area);
+      sub_areas.push_back(std::move(area));
     } else {
       status = AIS_ERR_BAD_SUB_SUB_MSG;
       return;
@@ -181,16 +181,6 @@ Ais8_366_22::Ais8_366_22(const char *nmea_payload, const size_t pad)
 
   assert(bits.GetRemaining() == 0);
   status = AIS_OK;
-}
-
-Ais8_366_22::~Ais8_366_22() {
-  // Switch to unique_ptr.
-  for (size_t i = 0; i < sub_areas.size(); i++) {
-    delete sub_areas[i];
-#ifndef NDEBUG
-    sub_areas[i] = NULL;
-#endif
-  }
 }
 
 // Lookup table for the scale factors to decode the length / distance fields.
@@ -270,7 +260,7 @@ Ais8_366_22_Text::Ais8_366_22_Text(const AisBitset &bits,
 }
 
 // Call the appropriate constructor
-Ais8_366_22_SubArea *
+std::unique_ptr<Ais8_366_22_SubArea>
 ais8_366_22_subarea_factory(const AisBitset &bits,
                             const size_t offset) {
   const Ais8_366_22_AreaShapeEnum area_shape =
@@ -278,17 +268,17 @@ ais8_366_22_subarea_factory(const AisBitset &bits,
 
   switch (area_shape) {
   case AIS8_366_22_SHAPE_CIRCLE:
-    return new Ais8_366_22_Circle(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Circle(bits, offset));
   case AIS8_366_22_SHAPE_RECT:
-    return new Ais8_366_22_Rect(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Rect(bits, offset));
   case AIS8_366_22_SHAPE_SECTOR:
-    return new Ais8_366_22_Sector(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Sector(bits, offset));
   case AIS8_366_22_SHAPE_POLYLINE:
-    return new Ais8_366_22_Polyline(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Polyline(bits, offset));
   case AIS8_366_22_SHAPE_POLYGON:
-    return new Ais8_366_22_Polygon(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Polygon(bits, offset));
   case AIS8_366_22_SHAPE_TEXT:
-    return new Ais8_366_22_Text(bits, offset);
+    return std::unique_ptr<Ais8_366_22_SubArea>(new Ais8_366_22_Text(bits, offset));
   case AIS8_366_22_SHAPE_RESERVED_6:  // FALLTHROUGH
   case AIS8_366_22_SHAPE_RESERVED_7:  // FALLTHROUGH
     // Leave area as 0 to indicate error
@@ -298,7 +288,7 @@ ais8_366_22_subarea_factory(const AisBitset &bits,
   default:
     assert(false);
   }
-  return nullptr;
+  return {};
 }
 
 }  // namespace libais

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -1134,7 +1134,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Circle *c =
-            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1153,7 +1154,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Rect *c =
-            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1171,7 +1173,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Sector *c =
-            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1189,7 +1192,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polyline *polyline =
-            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
+        assert(polyline != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYLINE);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polyline");
@@ -1215,7 +1219,8 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polygon *polygon =
-            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
+        assert(polygon != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYGON);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polygon");
@@ -1242,7 +1247,9 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_1_22_Text *text =
-            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
+        assert(text != nullptr);
+
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 
@@ -1887,7 +1894,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Circle *c =
-            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1905,7 +1913,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Rect *c =
-            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1923,7 +1932,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Sector *c =
-            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
+        assert(c != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1942,7 +1952,8 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Poly *poly =
-            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
+        assert(poly != nullptr);
 
         DictSafeSetItem(sub_area, "sub_area_type", msg.sub_areas[i]->getType());
         if (msg.sub_areas[i]->getType() == AIS8_366_22_SHAPE_POLYLINE)
@@ -1971,7 +1982,9 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_367_22_Text *text =
-            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
+            dynamic_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
+        assert(text != nullptr);
+
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 

--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -1134,7 +1134,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Circle *c =
-            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Circle*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1153,7 +1153,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Rect *c =
-            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Rect*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1171,7 +1171,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Sector *c =
-            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Sector*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1189,7 +1189,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polyline *polyline =
-            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Polyline*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYLINE);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polyline");
@@ -1215,7 +1215,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_1_22_Polygon *polygon =
-            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Polygon*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_POLYGON);
         DictSafeSetItem(sub_area, "sub_area_type_str", "polygon");
@@ -1242,7 +1242,7 @@ ais8_1_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_1_22_Text *text =
-            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_1_22_Text*>(msg.sub_areas[i].get());
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_1_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 
@@ -1887,7 +1887,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Circle *c =
-            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Circle*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_CIRCLE);
         if (c->radius_m == 0)
@@ -1905,7 +1905,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Rect *c =
-            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Rect*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_RECT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "rect");
@@ -1923,7 +1923,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Sector *c =
-            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Sector*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_SECTOR);
         DictSafeSetItem(sub_area, "sub_area_type_str", "sector");
@@ -1942,7 +1942,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
       {
         PyObject *sub_area = PyDict_New();
         Ais8_367_22_Poly *poly =
-            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Poly*>(msg.sub_areas[i].get());
 
         DictSafeSetItem(sub_area, "sub_area_type", msg.sub_areas[i]->getType());
         if (msg.sub_areas[i]->getType() == AIS8_366_22_SHAPE_POLYLINE)
@@ -1971,7 +1971,7 @@ ais8_367_22_append_pydict(const char *nmea_payload, PyObject *dict,
         PyObject *sub_area = PyDict_New();
 
         Ais8_367_22_Text *text =
-            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i]);
+            reinterpret_cast<Ais8_367_22_Text*>(msg.sub_areas[i].get());
         DictSafeSetItem(sub_area, "sub_area_type", AIS8_366_22_SHAPE_TEXT);
         DictSafeSetItem(sub_area, "sub_area_type_str", "text");
 


### PR DESCRIPTION
This PR is the first part of the resubmitted #209 .

This PR includes a first patch that proposes to use `std::unique_ptr` to manage subareas in `Ais8_1_22` and `Ais8_366_22`. The current implementation uses raw pointers and relies on destructors in order to do clean-up. The `std::unique_ptr` implementation is usually considered safer and less error prone.

The second patch changes some `reinterpred_cast` into `dynamic_cast` when casting from a pointer to parent class into a pointer to a child class.

Both commits are kept together because they inpact common lines.