### PR TITLE
ais_py.cpp: Ensure all references are cleared before raising ais_py_exception

### DIFF
--- a/src/libais/ais_py.cpp
+++ b/src/libais/ais_py.cpp
@@ -777,6 +777,7 @@ ais6_to_pydict(const char *nmea_payload, const size_t pad) {
   }
 
   if (status != AIS_OK) {
+    Py_DECREF(dict);
     PyErr_Format(ais_py_exception,
                  "Ais6: DAC:FI not known.  6:%d:%d %s",
                  msg.dac,
@@ -2117,6 +2118,7 @@ ais8_to_pydict(const char *nmea_payload, const size_t pad) {
   }
 
   if (status != AIS_OK) {
+    Py_DECREF(dict);
     PyErr_Format(ais_py_exception, "Ais8: %s",
                  AIS_STATUS_STRINGS[status]);
     return nullptr;
@@ -2634,6 +2636,7 @@ ais24_to_pydict(const char *nmea_payload, const size_t pad) {
   default:
     // status = AIS_ERR_BAD_MSG_CONTENT;
     // TODO(schwehr): setup python exception
+    Py_DECREF(dict);
     return nullptr;
   }
 


### PR DESCRIPTION
When a decoding error occured, some places did keep a reference to a
dict being constructed.  This patch makes sure that such reference is
cleared before returning raising an exception.