### PR TITLE
Fix logging line in TagQueue.put if no NMEA match is found

### DIFF
--- a/ais/tag_block.py
+++ b/ais/tag_block.py
@@ -136,7 +136,7 @@ class TagQueue(Queue.Queue):
         if decoded:
           msg['decoded'] = decoded
         else:
-          logger.info('No NMEA match for line: %d, %s', line_num, line)
+          logger.info('No NMEA match for line: %d, %s', self.line_num, line)
       Queue.Queue.put(self, msg)
       return
 


### PR DESCRIPTION
`TagQueueGroupsTest.testTwoLines` fails on Python 3.12:

```
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: %d format: a real number is required, not NoneType
Call stack:
  File "/<<PKGBUILDDIR>>/setup.py", line 75, in <module>
    setup(
  File "/usr/lib/python3/dist-packages/setuptools/__init__.py", line 107, in setup
    return distutils.core.setup(**attrs)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 185, in setup
    return run_commands(dist)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/core.py", line 201, in run_commands
    dist.run_commands()
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 969, in run_commands
    self.run_command(cmd)
  File "/usr/lib/python3/dist-packages/setuptools/dist.py", line 1233, in run_command
    super().run_command(command)
  File "/usr/lib/python3/dist-packages/setuptools/_distutils/dist.py", line 988, in run_command
    cmd_obj.run()
  File "/usr/lib/python3/dist-packages/setuptools/command/test.py", line 223, in run
    self.run_tests()
  File "/usr/lib/python3/dist-packages/setuptools/command/test.py", line 226, in run_tests
    test = unittest.main(
  File "/usr/lib/python3.11/unittest/main.py", line 102, in __init__
    self.runTests()
  File "/usr/lib/python3.11/unittest/main.py", line 274, in runTests
    self.result = testRunner.run(self.test)
  File "/usr/lib/python3.11/unittest/runner.py", line 217, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/suite.py", line 84, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/suite.py", line 122, in run
    test(result)
  File "/usr/lib/python3.11/unittest/case.py", line 678, in __call__
    return self.run(*args, **kwds)
  File "/usr/lib/python3.11/unittest/case.py", line 623, in run
    self._callTestMethod(testMethod)
  File "/usr/lib/python3.11/unittest/case.py", line 579, in _callTestMethod
    if method() is not None:
  File "/<<PKGBUILDDIR>>/test/tag_block_test.py", line 235, in testMultipleTagLines
    queue.put(r'\s:station1,c:1425344187*78\a')
  File "/<<PKGBUILDDIR>>/ais/tag_block.py", line 139, in put
    logger.info('No NMEA match for line: %d, %s', line_num, line)
Message: 'No NMEA match for line: %d, %s'
Arguments: (None, '\\s:station1,c:1425344187*78\\a')
```