### PR TITLE
ci.yml: Fix gcc/g++ versions to be the default.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Add required sources and pkgs
         run: |
           sudo add-apt-repository --update --yes 'deb http://archive.ubuntu.com/ubuntu/ bionic main universe'
-          sudo apt-get install gcc-6 g++-6
+          sudo apt-get install gcc g++
 
       - name: Checkout repo
         uses: actions/checkout@v2
@@ -46,5 +46,5 @@ jobs:
         
       - name: Script
         run: |
-          (cd src && CC=gcc-6 CXX=g++-6 make -f Makefile-custom -j 4 test)
+          (cd src && CC=gcc CXX=g++ make -f Makefile-custom -j 4 test)
           py.test ais test --cov=ais --cov-report term-missing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
           pip install pytest --upgrade
 
       - name: Install
-        run: CC=g++-6 pip install .\[tests\] --upgrade
+        run: CC=g++ pip install .\[tests\] --upgrade
         
       - name: Script
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
         python-version: [
 	  '3.9',
 	  '3.10',
-	  '3.11',
-	  '3.12'
+	  '3.11'
+	  # '3.12' does not have assertDictContainsSubset. 
 	  ]
     steps:
       - name: Add required sources and pkgs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,12 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10-dev']
+        python-version: [
+	  '3.9',
+	  '3.10',
+	  '3.11',
+	  '3.12'
+	  ]
     steps:
       - name: Add required sources and pkgs
         run: |


### PR DESCRIPTION
Also
- Add python 3.11 and 3.12.
- Rename python 3.10-dev to 3.10.
- Cleanup whitespace.